### PR TITLE
Give the Gradle daemon an explicit heap

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ org.gradle.workers.max=1
 org.gradle.caching = true
 org.gradle.parallel = true
 org.gradle.vfs.watch = true
+# shadowJar assembles a large (~190MB) fat jar; without an explicit heap the daemon runs on
+# Gradle's small default and GC-thrashes (looks like a hang at :grobid-core:shadowJar).
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 # from Java 9+
 #org.gradle.jvmargs=--add-modules=java.xml.bind,java.activation
 #systemProp.https.proxyHost=


### PR DESCRIPTION
shadowJar assembles a ~190MB fat jar. Without an explicit heap the daemon runs on Gradle's small default and GC-thrashes, which looks like a hang at :grobid-core:shadowJar.