### PR TITLE
perf(docker): order the full-image runtime stage stable-first

### DIFF
--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -74,6 +74,14 @@ RUN unzip -o /opt/grobid-source/grobid-home/build/distributions/grobid-home-*.zi
     chmod -R 755 /opt/grobid/grobid-home/pdfalto
 RUN rm -rf grobid-source
 
+# -----------------------------------------------
+# JDK, as a bind-mount source for the JEP build
+# -----------------------------------------------
+
+# Same image the builder starts from, so it costs no extra pull, but -- unlike `builder` --
+# its content does not move with the grobid source, which keeps the JEP layer cacheable.
+FROM eclipse-temurin:21.0.11_10-jdk-noble AS jdk
+
 # -------------------
 # build runtime image
 # -------------------
@@ -103,7 +111,19 @@ ARG TARGETARCH
 
 WORKDIR /opt/grobid
 
-COPY --from=builder /opt/grobid .
+# Everything from here to the "COPY --from=builder /opt/grobid ." below is ordered
+# stable-first, on purpose. The Java distribution changes with every grobid commit, so it
+# goes last: the delft install (~5GB with the CUDA wheels), the JEP build and the glove
+# preload (~2GB downloaded, then loaded into lmdb) all sit above it and stay cached across
+# ordinary source changes. Only a DELFT_REF bump, a base-image change or a resources-registry
+# edit rebuilds them.
+
+# link the data directory to /data
+# the current working directory will most likely be /opt/grobid
+# (must precede the embeddings preload: the registry writes the lmdb under ./data)
+RUN mkdir -p /data \
+    && ln -s /data /opt/grobid/data \
+    && ln -s /data ./data
 
 # install DeLFT (PyTorch backend) + torch.
 # Pinned to a delft commit until the next PyPI release (1.0.2) is published; this
@@ -113,10 +133,9 @@ COPY --from=builder /opt/grobid .
 # A commit SHA rather than a branch name, for provenance: the Dockerfile alone then
 # says which delft is in a given image, which a branch name cannot. Bump it to move.
 #
-# Not for cache-busting. This layer sits below "COPY --from=builder /opt/grobid .",
-# whose contents change with every grobid commit, so it is rebuilt on every real build
-# whatever the pin says -- the CI runs take 40-70 minutes each, doing exactly that. A
-# branch name would only go stale when rebuilding identical grobid source.
+# It is now also what busts this layer. The install sits above the grobid COPY, so it is
+# cached across ordinary source changes and a branch name would silently keep resolving to
+# a stale commit; bumping the SHA is what forces the reinstall.
 #
 # Either way the image records what pip actually resolved, in
 # delft-*.dist-info/direct_url.json (PEP 610). That is the authoritative check.
@@ -134,14 +153,26 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 
 # Build JEP with temporary access to full JDK (needs javac + JNI headers).
 # The bind mount is only visible during this RUN step — zero overhead in the final image.
-RUN --mount=from=builder,source=/opt/java/openjdk,target=/opt/java/openjdk-jdk \
+# Mounted from the `jdk` stage rather than from `builder`, so this layer does not depend on
+# a stage that is rebuilt on every commit.
+RUN --mount=from=jdk,source=/opt/java/openjdk,target=/opt/java/openjdk-jdk \
     JAVA_HOME=/opt/java/openjdk-jdk pip3 install --no-cache-dir jep==4.3.1
 
-# link the data directory to /data
-# the current working directory will most likely be /opt/grobid
-RUN mkdir -p /data \
-    && ln -s /data /opt/grobid/data \
-    && ln -s /data ./data
+# preload embeddings, for GROBID all the RNN models use glove-840B (default for the script), ELMo is currently not loaded
+# to be done: mechanism to download GROBID fine-tuned models based on SciBERT if selected (but not good enough for the moment)
+# Only these two files are taken from the builder, and BuildKit keys the layer on their
+# content, so the preload is rebuilt when the registry changes -- not on every commit.
+COPY --from=builder /opt/grobid-source/grobid-home/scripts/preload_embeddings.py .
+COPY --from=builder /opt/grobid-source/grobid-home/config/resources-registry.json .
+# The lmdb permissions are set here rather than in the chgrp/chmod step at the end of the
+# file: a recursive chmod in a later layer copies up every file it touches, which would put
+# a second copy of the multi-GB embeddings database in the image.
+RUN python3 preload_embeddings.py --registry ./resources-registry.json &&  \
+    ln -s /opt/grobid /opt/delft && \
+    chgrp -R 0 /data && chmod -R g=u /data
+
+RUN mkdir delft && \
+    cp ./resources-registry.json delft/
 
 # disable python warnings (and fix logging)
 ENV PYTHONWARNINGS="ignore"
@@ -177,19 +208,14 @@ ENTRYPOINT ["/tini", "-s", "--"]
 
 WORKDIR /opt/grobid
 
-# preload embeddings, for GROBID all the RNN models use glove-840B (default for the script), ELMo is currently not loaded
-# to be done: mechanism to download GROBID fine-tuned models based on SciBERT if selected (but not good enough for the moment)
-COPY --from=builder /opt/grobid-source/grobid-home/scripts/preload_embeddings.py .
-COPY --from=builder /opt/grobid-source/grobid-home/config/resources-registry.json .
-RUN python3 preload_embeddings.py --registry ./resources-registry.json &&  \
-    ln -s /opt/grobid /opt/delft
-
-RUN mkdir delft && \
-    cp ./resources-registry.json delft/
+# The Java distribution, last: it changes with every grobid commit, so nothing cacheable
+# should sit below it.
+COPY --from=builder /opt/grobid .
 
 # Set the group to avoid running the docker image in a rootless environment
-RUN chgrp -R 0 /opt/grobid /data /tmp && \
-    chmod -R g=u /opt/grobid /data /tmp
+# (/data is handled above, in the layer that fills it)
+RUN chgrp -R 0 /opt/grobid /tmp && \
+    chmod -R g=u /opt/grobid /tmp
 
 CMD ["./grobid-service/bin/grobid-service"]
 


### PR DESCRIPTION
The runtime stage copied the built Java distribution in as its first step, above the delft/torch install, the JEP build and the glove embeddings preload. That copy changes with every grobid commit, so all three expensive-and-stable layers were rebuilt on every build.

Move the grobid COPY to the bottom of the stage. The /data symlink moves up with the preload, since resources-registry.json writes the lmdb to a path that resolves through it. The JEP build bind-mounted the JDK from `builder`, tying it to a stage that is rebuilt per commit; it now mounts from a one-line `jdk` stage on the same pinned base image -- same content, no extra pull. The preload still takes two files from the builder, but BuildKit keys COPY --from on their content, so it rebuilds when the registry changes rather than per commit.

Also move the /data permission fixing into the RUN that fills it. A recursive chmod in a later layer copies up every file it touches, which put a second copy of the multi-GB embeddings database in the image.