### PR TITLE
fix: skip null biblio items in processCitationList

### DIFF
--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -62,7 +62,6 @@ jobs:
 
   docker-build-amd64:
     needs: [build]
-    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -85,6 +84,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
+        # Forks have no Docker Hub credentials; they build without pushing.
+        if: github.event.repository.fork == false
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
@@ -98,13 +99,13 @@ jobs:
           platforms: linux/amd64
           build-args: |
             GROBID_VERSION=${{ steps.version.outputs.value }}
-          outputs: type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true
+          # `type=cacheonly` builds every layer and discards the image: forks only verify that Dockerfile.crf still builds.
+          outputs: ${{ github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,scope=amd64,mode=max
 
   docker-build-arm64:
     needs: [build]
-    if: github.event.repository.fork == false
     runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -127,6 +128,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
+        # Forks have no Docker Hub credentials; they build without pushing.
+        if: github.event.repository.fork == false
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
@@ -140,12 +143,15 @@ jobs:
           platforms: linux/arm64
           build-args: |
             GROBID_VERSION=${{ steps.version.outputs.value }}
-          outputs: type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true
+          # `type=cacheonly` builds every layer and discards the image: forks only verify that Dockerfile.crf still builds.
+          outputs: ${{ github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,scope=arm64,mode=max
 
   docker-merge:
     needs: [docker-build-amd64, docker-build-arm64]
+    # Forks push no digests, so there is nothing to merge or publish.
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -1,6 +1,6 @@
 name: Build unstable
 
-on: [ push ]
+on: [ push, pull_request ]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -9,6 +9,8 @@ concurrency:
 
 jobs:
   build:
+    # Same-repo branches already get a `push` run; only fork PRs need the `pull_request` event.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, ubuntu-24.04-arm, macos-15-intel ]
@@ -41,18 +43,21 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         run: ./gradlew assemble test -PskipCoverage --info --stacktrace
 
+      # Coverage upload needs a writable GITHUB_TOKEN, which fork pull requests do not get.
       - name: Run Coveralls Gradle task
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
         run: ./gradlew coveralls --info --stacktrace
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         if: success() || failure() # always run even if the previous step fails
+        # Creating the check run needs write access, which fork pull requests do not get.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Coveralls GitHub Action
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,8 +89,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        # Forks have no Docker Hub credentials; they build without pushing.
-        if: github.event.repository.fork == false
+        # Fork pushes and fork PRs have no Docker Hub credentials; they build without pushing.
+        if: github.event_name == 'push' && github.event.repository.fork == false
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
@@ -100,7 +105,7 @@ jobs:
           build-args: |
             GROBID_VERSION=${{ steps.version.outputs.value }}
           # `type=cacheonly` builds every layer and discards the image: forks only verify that Dockerfile.crf still builds.
-          outputs: ${{ github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+          outputs: ${{ github.event_name == 'push' && github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,scope=amd64,mode=max
 
@@ -128,8 +133,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        # Forks have no Docker Hub credentials; they build without pushing.
-        if: github.event.repository.fork == false
+        # Fork pushes and fork PRs have no Docker Hub credentials; they build without pushing.
+        if: github.event_name == 'push' && github.event.repository.fork == false
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
@@ -144,14 +149,14 @@ jobs:
           build-args: |
             GROBID_VERSION=${{ steps.version.outputs.value }}
           # `type=cacheonly` builds every layer and discards the image: forks only verify that Dockerfile.crf still builds.
-          outputs: ${{ github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+          outputs: ${{ github.event_name == 'push' && github.event.repository.fork == false && 'type=image,name=lfoppiano/grobid,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,scope=arm64,mode=max
 
   docker-merge:
     needs: [docker-build-amd64, docker-build-arm64]
-    # Forks push no digests, so there is nothing to merge or publish.
-    if: github.event.repository.fork == false
+    # Fork pushes and fork PRs push no digests, so there is nothing to merge or publish.
+    if: github.event_name == 'push' && github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
@@ -353,7 +353,6 @@ public class GrobidRestProcessString {
                         responseContent.append("@misc{b").append(n).append(",\n}\n");
                     } else {
                         responseContent.append(biblioItem.toBibTeX(biblioItem.generateBibTeXKey(), config));
-                        responseContent.append("\n");
                     }
                     n++;
                 }
@@ -381,7 +380,6 @@ public class GrobidRestProcessString {
                         responseContent.append("\t\t\t\t\t<biblStruct xml:id=\"b").append(n).append("\"/>\n");
                     } else {
                         responseContent.append(biblioItem.toTEI(n, config));
-                        responseContent.append("\n");
                     }
                     n++;
                 }

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
@@ -347,6 +347,9 @@ public class GrobidRestProcessString {
             } else if (expectedResponseType == ExpectedResponseType.BIBTEX) {
                 StringBuilder responseContent = new StringBuilder();
                 for (BiblioItem biblioItem : biblioItems) {
+                    if (biblioItem == null) {
+                        continue;
+                    }
                     responseContent.append(biblioItem.toBibTeX(biblioItem.generateBibTeXKey(), config));
                     responseContent.append("\n");
                 }
@@ -369,8 +372,10 @@ public class GrobidRestProcessString {
                                 "<body/>\n\t\t<back>\n\t\t\t<div>\n\t\t\t\t<listBibl>\n");
                 int n = 0;
                 for (BiblioItem biblioItem : biblioItems) {
-                    responseContent.append(biblioItem.toTEI(n, config));
-                    responseContent.append("\n");
+                    if (biblioItem != null) {
+                        responseContent.append(biblioItem.toTEI(n, config));
+                        responseContent.append("\n");
+                    }
                     n++;
                 }
                 responseContent.append("\t\t\t\t</listBibl>\n\t\t\t</div>\n\t\t</back>\n\t</text>\n</TEI>\n");

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessString.java
@@ -346,12 +346,16 @@ public class GrobidRestProcessString {
                 response = Response.status(Status.NO_CONTENT).build();
             } else if (expectedResponseType == ExpectedResponseType.BIBTEX) {
                 StringBuilder responseContent = new StringBuilder();
+                int n = 0;
                 for (BiblioItem biblioItem : biblioItems) {
                     if (biblioItem == null) {
-                        continue;
+                        // Keep output length aligned with input so clients can zip lists.
+                        responseContent.append("@misc{b").append(n).append(",\n}\n");
+                    } else {
+                        responseContent.append(biblioItem.toBibTeX(biblioItem.generateBibTeXKey(), config));
+                        responseContent.append("\n");
                     }
-                    responseContent.append(biblioItem.toBibTeX(biblioItem.generateBibTeXKey(), config));
-                    responseContent.append("\n");
+                    n++;
                 }
                 response = Response.status(Status.OK)
                         .entity(responseContent.toString())
@@ -372,7 +376,10 @@ public class GrobidRestProcessString {
                                 "<body/>\n\t\t<back>\n\t\t\t<div>\n\t\t\t\t<listBibl>\n");
                 int n = 0;
                 for (BiblioItem biblioItem : biblioItems) {
-                    if (biblioItem != null) {
+                    if (biblioItem == null) {
+                        // Keep output length aligned with input so clients can zip lists.
+                        responseContent.append("\t\t\t\t\t<biblStruct xml:id=\"b").append(n).append("\"/>\n");
+                    } else {
                         responseContent.append(biblioItem.toTEI(n, config));
                         responseContent.append("\n");
                     }

--- a/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
+++ b/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
@@ -42,8 +42,8 @@ public class GrobidRestProcessStringTest {
     private static final String VALID_CITATION = "Graff, Expert. Opin. Ther. Targets (2002) 6(1): 103-113";
     private static final String EMPTY_CITATION = "";
     private static final String NBSP_CITATION = "\u00A0";
-    private static final String TEI_FRAGMENT = "<biblStruct xml:id=\"b0\"/>";
-    private static final String BIBTEX_FRAGMENT = "@article{graff2002,}";
+    private static final String TEI_FRAGMENT = "<biblStruct xml:id=\"b0\"/>\n";
+    private static final String BIBTEX_FRAGMENT = "@article{graff2002,}\n";
 
     private GrobidRestProcessString target;
     private GrobidAnalysisConfig config;
@@ -70,6 +70,8 @@ public class GrobidRestProcessStringTest {
         assertEquals(citations.size(), countOccurrences(body, "<biblStruct"));
         assertTrue(body.contains("xml:id=\"b1\""));
         assertTrue(body.contains("xml:id=\"b2\""));
+        // Real citations already end with a newline; do not insert a blank line after them.
+        assertEquals(-1, body.indexOf(TEI_FRAGMENT + "\n"));
     }
 
     @Test
@@ -85,6 +87,7 @@ public class GrobidRestProcessStringTest {
         assertTrue(body.contains(BIBTEX_FRAGMENT));
         // One BibTeX entry per input citation, including empty slots.
         assertEquals(citations.size(), countOccurrences(body, "@"));
+        assertEquals(-1, body.indexOf(BIBTEX_FRAGMENT + "\n"));
     }
 
     private static int countOccurrences(String haystack, String needle) {

--- a/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
+++ b/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
@@ -66,6 +66,10 @@ public class GrobidRestProcessStringTest {
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         String body = (String) response.getEntity();
         assertTrue(body.contains(TEI_FRAGMENT));
+        // Output biblStruct count must match input citation count (including empty slots).
+        assertEquals(citations.size(), countOccurrences(body, "<biblStruct"));
+        assertTrue(body.contains("xml:id=\"b1\""));
+        assertTrue(body.contains("xml:id=\"b2\""));
     }
 
     @Test
@@ -79,6 +83,18 @@ public class GrobidRestProcessStringTest {
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         String body = (String) response.getEntity();
         assertTrue(body.contains(BIBTEX_FRAGMENT));
+        // One BibTeX entry per input citation, including empty slots.
+        assertEquals(citations.size(), countOccurrences(body, "@"));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int from = 0;
+        while ((from = haystack.indexOf(needle, from)) >= 0) {
+            count++;
+            from += needle.length();
+        }
+        return count;
     }
 
     private BiblioItem parsedItem() {

--- a/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
+++ b/grobid-service/src/test/java/org/grobid/service/process/GrobidRestProcessStringTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2008-2026 GROBID contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grobid.service.process;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.grobid.core.data.BiblioItem;
+import org.grobid.core.engines.Engine;
+import org.grobid.core.engines.config.GrobidAnalysisConfig;
+import org.grobid.core.factory.GrobidPoolingFactory;
+import org.grobid.service.util.ExpectedResponseType;
+
+public class GrobidRestProcessStringTest {
+
+    private static final String VALID_CITATION = "Graff, Expert. Opin. Ther. Targets (2002) 6(1): 103-113";
+    private static final String EMPTY_CITATION = "";
+    private static final String NBSP_CITATION = "\u00A0";
+    private static final String TEI_FRAGMENT = "<biblStruct xml:id=\"b0\"/>";
+    private static final String BIBTEX_FRAGMENT = "@article{graff2002,}";
+
+    private GrobidRestProcessString target;
+    private GrobidAnalysisConfig config;
+
+    @Before
+    public void setUp() {
+        target = new GrobidRestProcessString();
+        config = GrobidAnalysisConfig.defaultInstance();
+    }
+
+    @Test
+    public void processCitationList_emptyAndNbspAmongCitations_xml_doesNotReturn500() throws Exception {
+        BiblioItem parsed = parsedItem();
+        List<String> citations = Arrays.asList(VALID_CITATION, EMPTY_CITATION, NBSP_CITATION);
+        // CitationParser inserts null BiblioItem for blank / NBSP-only raw strings.
+        List<BiblioItem> parsedItems = Arrays.asList(parsed, null, null);
+
+        Response response = processCitationList(citations, parsedItems, ExpectedResponseType.XML);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains(TEI_FRAGMENT));
+    }
+
+    @Test
+    public void processCitationList_emptyAndNbspAmongCitations_bibtex_doesNotReturn500() throws Exception {
+        BiblioItem parsed = parsedItem();
+        List<String> citations = Arrays.asList(VALID_CITATION, EMPTY_CITATION, NBSP_CITATION);
+        List<BiblioItem> parsedItems = Arrays.asList(parsed, null, null);
+
+        Response response = processCitationList(citations, parsedItems, ExpectedResponseType.BIBTEX);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains(BIBTEX_FRAGMENT));
+    }
+
+    private BiblioItem parsedItem() {
+        BiblioItem parsed = mock(BiblioItem.class);
+        when(parsed.toTEI(anyInt(), any(GrobidAnalysisConfig.class))).thenReturn(TEI_FRAGMENT);
+        when(parsed.generateBibTeXKey()).thenReturn("graff2002");
+        when(parsed.toBibTeX(any(), any(GrobidAnalysisConfig.class))).thenReturn(BIBTEX_FRAGMENT);
+        return parsed;
+    }
+
+    private Response processCitationList(
+            List<String> citations,
+            List<BiblioItem> parsedItems,
+            ExpectedResponseType responseType) throws Exception {
+        Engine engine = mock(Engine.class);
+        when(engine.processRawReferences(citations, config.getConsolidateCitations())).thenReturn(parsedItems);
+
+        try (MockedStatic<Engine> engineStatic = Mockito.mockStatic(Engine.class);
+                MockedStatic<GrobidPoolingFactory> poolingFactory = Mockito.mockStatic(GrobidPoolingFactory.class)) {
+            engineStatic.when(() -> Engine.getEngine(true)).thenReturn(engine);
+            poolingFactory.when(() -> GrobidPoolingFactory.returnEngine(engine)).thenAnswer(invocation -> null);
+
+            return target.processCitationList(citations, config, responseType);
+        }
+    }
+}


### PR DESCRIPTION
`processCitationList` returned HTTP 500 with an empty body when one entry in the list was blank (or NBSP-only, which slips `StringUtils.isNotBlank()`). `processCitation` already returns 204 for the same input.

Empty slots come back as null `BiblioItem`s. The TEI/BibTeX serialize loops called `toTEI`/`toBibTeX` without a null check and NPEd. Skip those slots so a mixed list still returns 200 with the parsed citations.

Fixes #1551