### PR TITLE
Add citation training data for bracketed medium labels before a URL

### DIFF
--- a/grobid-trainer/resources/dataset/citation/corpus/software_dataset_citations_batch.xml
+++ b/grobid-trainer/resources/dataset/citation/corpus/software_dataset_citations_batch.xml
@@ -1,24 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tei xmlns="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML">
 <listBibl>
-<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.1234567</ptr></bibl>
-<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <publisher>Zenodo</publisher>.</bibl>
-<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <idno type="DOI">doi:10.5281/zenodo.1234567</idno></bibl>
 <bibl><author>Egense, T.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 <bibl><author>Egense, T. &amp; Eskildsen, T.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 <bibl><author>Egense, T., Eskildsen, T. &amp; Lauridsen, J.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 <bibl><author>Egense, T., Eskildsen, T., Lauridsen, J. &amp; O'Brien, B.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 <bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B. &amp; Jackson, A.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 <bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B., Jackson, A. &amp; Bellony, L.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
-<bibl><author>Jansen, M.</author> (<date>2024</date>). <title level="m">InternetArchiveExtractor (Version 0.0.8) [Python]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.10234567</ptr></bibl>
-<bibl><author>Jansen, M. &amp; Keller, P.</author> (<date>2024</date>). <title level="m">InternetArchiveExtractor (Version 0.0.8) [Python]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.10234567</ptr></bibl>
-<bibl><author>Torres, L.</author> (<date>2022</date>). <title level="m">Global surface temperature anomalies, 1880-2021 [Data set]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.5678901</ptr></bibl>
-<bibl><author>Torres, L. &amp; Bianchi, R.</author> (<date>2022</date>). <title level="m">Global surface temperature anomalies, 1880-2021 [Data set]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.5678901</ptr></bibl>
-<bibl><author>Nakamura, H., Patel, S. &amp; Dubois, C.</author> (<date>2023</date>). <title level="m">River discharge records for the Rhône basin [Dataset]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.7890123</ptr></bibl>
-<bibl><author>Whitfield, D.</author> (<date>2021</date>). <title level="m">audio-align: forced alignment for speech corpora [Computer software]</title>. <ptr type="web">https://github.com/dwhitfield/audio-align</ptr></bibl>
-<bibl><author>Whitfield, D. &amp; Reyes, M.</author> (<date>2021</date>). <title level="m">audio-align: forced alignment for speech corpora [Computer software]</title>. <ptr type="web">https://github.com/dwhitfield/audio-align</ptr></bibl>
-<bibl><author>Lindqvist, A.</author> (<date>2025</date>). <title level="m">Baltic Sea salinity profiles [Dataset]</title> <ptr type="web">https://doi.org/10.5281/zenodo.2233445</ptr></bibl>
-<bibl><author>Park, J.</author> (<date>2024</date>). <title level="m">Neural approaches to speaker diarization [Preprint]</title>. <ptr type="web">https://doi.org/10.48550/arXiv.2024.01234</ptr></bibl>
-<bibl><author>Costa, R.</author> (<date>2019</date>). <title level="m">Historical weather station readings [Machine-readable data file]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.334455</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B., Jackson, A., Bellony, L. &amp; Thogersen, J.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B., Jackson, A., Bellony, L., Thogersen, J. &amp; Johnston, V. H.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
 </listBibl>
 </tei>

--- a/grobid-trainer/resources/dataset/citation/corpus/software_dataset_citations_batch.xml
+++ b/grobid-trainer/resources/dataset/citation/corpus/software_dataset_citations_batch.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tei xmlns="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML">
+<listBibl>
+<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.1234567</ptr></bibl>
+<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <publisher>Zenodo</publisher>.</bibl>
+<bibl><author>Smith, J.</author> (<date>2020</date>). <title level="m">Alpha [Computer software]</title>. <idno type="DOI">doi:10.5281/zenodo.1234567</idno></bibl>
+<bibl><author>Egense, T.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T. &amp; Eskildsen, T.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T. &amp; Lauridsen, J.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T., Lauridsen, J. &amp; O'Brien, B.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B. &amp; Jackson, A.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Egense, T., Eskildsen, T., Lauridsen, J., O'Brien, B., Jackson, A. &amp; Bellony, L.</author> (<date>2026</date>). <title level="m">SolrWayback (Version 5.4.1) [Computer software]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.18314399</ptr></bibl>
+<bibl><author>Jansen, M.</author> (<date>2024</date>). <title level="m">InternetArchiveExtractor (Version 0.0.8) [Python]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.10234567</ptr></bibl>
+<bibl><author>Jansen, M. &amp; Keller, P.</author> (<date>2024</date>). <title level="m">InternetArchiveExtractor (Version 0.0.8) [Python]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.10234567</ptr></bibl>
+<bibl><author>Torres, L.</author> (<date>2022</date>). <title level="m">Global surface temperature anomalies, 1880-2021 [Data set]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.5678901</ptr></bibl>
+<bibl><author>Torres, L. &amp; Bianchi, R.</author> (<date>2022</date>). <title level="m">Global surface temperature anomalies, 1880-2021 [Data set]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.5678901</ptr></bibl>
+<bibl><author>Nakamura, H., Patel, S. &amp; Dubois, C.</author> (<date>2023</date>). <title level="m">River discharge records for the Rhône basin [Dataset]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.7890123</ptr></bibl>
+<bibl><author>Whitfield, D.</author> (<date>2021</date>). <title level="m">audio-align: forced alignment for speech corpora [Computer software]</title>. <ptr type="web">https://github.com/dwhitfield/audio-align</ptr></bibl>
+<bibl><author>Whitfield, D. &amp; Reyes, M.</author> (<date>2021</date>). <title level="m">audio-align: forced alignment for speech corpora [Computer software]</title>. <ptr type="web">https://github.com/dwhitfield/audio-align</ptr></bibl>
+<bibl><author>Lindqvist, A.</author> (<date>2025</date>). <title level="m">Baltic Sea salinity profiles [Dataset]</title> <ptr type="web">https://doi.org/10.5281/zenodo.2233445</ptr></bibl>
+<bibl><author>Park, J.</author> (<date>2024</date>). <title level="m">Neural approaches to speaker diarization [Preprint]</title>. <ptr type="web">https://doi.org/10.48550/arXiv.2024.01234</ptr></bibl>
+<bibl><author>Costa, R.</author> (<date>2019</date>). <title level="m">Historical weather station readings [Machine-readable data file]</title>. <ptr type="web">https://doi.org/10.5281/zenodo.334455</ptr></bibl>
+</listBibl>
+</tei>


### PR DESCRIPTION
## What

Adds 19 hand-annotated `<bibl>` training examples to
`grobid-trainer/resources/dataset/citation/corpus/` covering APA-style
software/dataset citations where a bracketed medium label (e.g.
`[Computer software]`, `[Dataset]`, `[Preprint]`) is immediately
followed by a URL, with no `[Online]. Available:` phrase in between.

## Why

#1556 reports that GROBID drops the closing `]` from a citation title
when the reference ends with a URL, e.g.:

```
Smith, J. (2020). Alpha [Computer software]. https://doi.org/10.5281/zenodo.1234567
```

extracts `<title level="m">Alpha [Computer software</title>` instead of
`...software]</title>`. The issue also documents a related failure
where the title disappears entirely as author count increases, for the
same "bracket immediately before a URL" pattern.

I traced this through `CitationParser.resultExtractionLayoutTokens`
(grobid-core): the title text is built directly from the citation
model's per-token cluster labels (`clusterContent` from
`clusteror.cluster()`), with no string post-processing in between. So
this isn't a Java-side bug to patch — the label boundary between
`<title>` and `<ptr type="web">` is learned entirely from the training
corpus.

I checked the existing corpus for this pattern: there are ~29 places
where `]` sits right before a `<ptr type="web">`, but in every one I
found, the bracket closes an `[Online]` aside (untagged transition
text before "Available:"), never a bracketed label that is part of the
title itself with no such phrase in between. That gap is a plausible
explanation for the model treating the bracket as belonging to the
URL/transition zone rather than the title when there's no `[Online]`
cue.

## What this doesn't do

I don't have Java/Gradle available in the environment I used to put
this together, so I could not run this through
`CitationTrainer`/`generateTrainingData` or retrain the model to
confirm the fix end-to-end. The XML is well-formed and follows
`doc/training/Bibliographical-references.md` (checked against many
existing corpus examples for tag conventions, e.g. `doi.org` URLs are
tagged `<ptr type="web">` throughout the corpus, not `<idno type="DOI">`,
which I matched here too). Happy to adjust the annotations if I've
misread a convention, or to add more variants if useful — this doesn't
close #1556 on its own since the shipped model needs a retrain to pick
it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)